### PR TITLE
Update container to include build-essential

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ LABEL name="LALSuite Runtime Debian Jessie" \
       support="Reference Platform"
 
 RUN apt-get update && \
-      apt-get --assume-yes install python-glue lscsoft-lalsuite && \
+      apt-get --assume-yes install build-essential python-glue lscsoft-lalsuite && \
       apt-get --assume-yes remove lal && \
+      apt-get clean && \
       rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is not a large addition because we already have lots of compilers installed via dependency chain. It basically adds `make`.